### PR TITLE
fireStore에 저장 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ Secrets.plist
 .env.local
 
 GoogleService-Info.plist
+**/GoogleService-Info.plist
+For\ Me/GoogleService-Info.plist

--- a/For Me.xcodeproj/project.pbxproj
+++ b/For Me.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		815D17602D890753005437E5 /* UserIdClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815D175F2D89074E005437E5 /* UserIdClass.swift */; };
 		81986C992D6ACCB400A87F1A /* Hakgyoansim Badasseugi TTF B.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 81986C952D6ACCB400A87F1A /* Hakgyoansim Badasseugi TTF B.ttf */; };
 		81986C9A2D6ACCB400A87F1A /* Hakgyoansim Geurimilgi TTF R.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 81986C972D6ACCB400A87F1A /* Hakgyoansim Geurimilgi TTF R.ttf */; };
 		81986C9B2D6ACCB400A87F1A /* Hakgyoansim Badasseugi TTF L.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 81986C962D6ACCB400A87F1A /* Hakgyoansim Badasseugi TTF L.ttf */; };
@@ -21,10 +22,11 @@
 		81B190942D86E378004F2478 /* GPTFunction.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B190932D86E376004F2478 /* GPTFunction.swift.swift */; };
 		81B190962D86FC02004F2478 /* SummaryChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B190952D86FBF7004F2478 /* SummaryChat.swift */; };
 		81B190982D87BE66004F2478 /* SaveRecordPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B190972D87BE56004F2478 /* SaveRecordPage.swift */; };
-		81B190A92D880047004F2478 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 81B190A82D880047004F2478 /* GoogleService-Info.plist */; };
 		81B190AC2D880098004F2478 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 81B190AB2D880098004F2478 /* FirebaseAnalytics */; };
 		81B190AE2D880098004F2478 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 81B190AD2D880098004F2478 /* FirebaseCore */; };
 		81B190B02D880098004F2478 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 81B190AF2D880098004F2478 /* FirebaseFirestore */; };
+		81B190B22D880841004F2478 /* FirStoreSave.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B190B12D880840004F2478 /* FirStoreSave.swift */; };
+		81B190B42D88114B004F2478 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 81B190B32D88114B004F2478 /* GoogleService-Info.plist */; };
 		81C1582F2D6ACA2D00B9F553 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81C1582B2D6ACA2D00B9F553 /* ContentView.swift */; };
 		81C158302D6ACA2D00B9F553 /* For_MeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81C1582D2D6ACA2D00B9F553 /* For_MeApp.swift */; };
 		81C158312D6ACA2D00B9F553 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 81C158282D6ACA2D00B9F553 /* Preview Assets.xcassets */; };
@@ -34,6 +36,7 @@
 
 /* Begin PBXFileReference section */
 		7F9B560056E38D713674B334 /* Pods-For Me.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-For Me.release.xcconfig"; path = "Target Support Files/Pods-For Me/Pods-For Me.release.xcconfig"; sourceTree = "<group>"; };
+		815D175F2D89074E005437E5 /* UserIdClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdClass.swift; sourceTree = "<group>"; };
 		81986C952D6ACCB400A87F1A /* Hakgyoansim Badasseugi TTF B.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Hakgyoansim Badasseugi TTF B.ttf"; sourceTree = "<group>"; };
 		81986C962D6ACCB400A87F1A /* Hakgyoansim Badasseugi TTF L.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Hakgyoansim Badasseugi TTF L.ttf"; sourceTree = "<group>"; };
 		81986C972D6ACCB400A87F1A /* Hakgyoansim Geurimilgi TTF R.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Hakgyoansim Geurimilgi TTF R.ttf"; sourceTree = "<group>"; };
@@ -50,7 +53,8 @@
 		81B190932D86E376004F2478 /* GPTFunction.swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTFunction.swift.swift; sourceTree = "<group>"; };
 		81B190952D86FBF7004F2478 /* SummaryChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryChat.swift; sourceTree = "<group>"; };
 		81B190972D87BE56004F2478 /* SaveRecordPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveRecordPage.swift; sourceTree = "<group>"; };
-		81B190A82D880047004F2478 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		81B190B12D880840004F2478 /* FirStoreSave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirStoreSave.swift; sourceTree = "<group>"; };
+		81B190B32D88114B004F2478 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		81C158162D6ACA2300B9F553 /* For Me.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "For Me.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81C158282D6ACA2D00B9F553 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		81C1582A2D6ACA2D00B9F553 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -124,6 +128,8 @@
 		81C1582E2D6ACA2D00B9F553 /* For Me */ = {
 			isa = PBXGroup;
 			children = (
+				81B190B12D880840004F2478 /* FirStoreSave.swift */,
+				815D175F2D89074E005437E5 /* UserIdClass.swift */,
 				81B190972D87BE56004F2478 /* SaveRecordPage.swift */,
 				81B190952D86FBF7004F2478 /* SummaryChat.swift */,
 				81B190932D86E376004F2478 /* GPTFunction.swift.swift */,
@@ -142,7 +148,7 @@
 				81986CBC2D83FDE000A87F1A /* ClickDate */,
 				81C1582C2D6ACA2D00B9F553 /* For_Me.entitlements */,
 				81C1582D2D6ACA2D00B9F553 /* For_MeApp.swift */,
-				81B190A82D880047004F2478 /* GoogleService-Info.plist */,
+				81B190B32D88114B004F2478 /* GoogleService-Info.plist */,
 			);
 			path = "For Me";
 			sourceTree = "<group>";
@@ -232,7 +238,7 @@
 				81986C992D6ACCB400A87F1A /* Hakgyoansim Badasseugi TTF B.ttf in Resources */,
 				81986C9A2D6ACCB400A87F1A /* Hakgyoansim Geurimilgi TTF R.ttf in Resources */,
 				81986C9B2D6ACCB400A87F1A /* Hakgyoansim Badasseugi TTF L.ttf in Resources */,
-				81B190A92D880047004F2478 /* GoogleService-Info.plist in Resources */,
+				81B190B42D88114B004F2478 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -270,6 +276,8 @@
 			files = (
 				81986CA12D6B31BC00A87F1A /* HomePage.swift in Sources */,
 				81C1582F2D6ACA2D00B9F553 /* ContentView.swift in Sources */,
+				815D17602D890753005437E5 /* UserIdClass.swift in Sources */,
+				81B190B22D880841004F2478 /* FirStoreSave.swift in Sources */,
 				81B190962D86FC02004F2478 /* SummaryChat.swift in Sources */,
 				81B190942D86E378004F2478 /* GPTFunction.swift.swift in Sources */,
 				81C158302D6ACA2D00B9F553 /* For_MeApp.swift in Sources */,

--- a/For Me/FirStoreSave.swift
+++ b/For Me/FirStoreSave.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Firebase
+import FirebaseFirestore
+
+class FirestoreManager {
+    // 싱글톤 패턴 구현
+    static let shared = FirestoreManager()
+    
+    // Firestore 데이터베이스 참조
+    private let db = Firestore.firestore()
+    
+    // 컬렉션 이름 상수
+    private let collectionName = "DailyRecords"
+    private let subCollectionName = "records"
+    
+    private init() {}
+    
+    // 기록 저장 함수
+    func saveRecord(date: Date, score: Int, tasks: [String], summary: String?, completion: @escaping (Bool, Error?) -> Void) {
+        // 사용자 ID 가져오기
+        let userId = UserIdManager.shared.getUserId()
+        
+        // 날짜 형식 변환
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let dateString = dateFormatter.string(from: date)
+        
+        // 저장할 데이터 구성
+        var recordData: [String: Any] = [
+            "date": dateString,
+            "score": score,
+            "tasks": tasks,
+            "updatedAt": FieldValue.serverTimestamp()
+        ]
+        
+        // summary가 nil이 아닌 경우에만 추가
+        if let summary = summary {
+            recordData["summary"] = summary
+        }
+        
+        // 문서 참조 생성
+        let docRef = db.collection(collectionName).document(userId)
+            .collection(subCollectionName).document(dateString)
+        
+        // 문서가 존재하는지 확인
+        docRef.getDocument { (document, error) in
+            if let error = error {
+                print("문서 확인 중 오류 발생: \(error.localizedDescription)")
+                completion(false, error)
+                return
+            }
+            
+            if let document = document, document.exists {
+                // 기존 문서 업데이트
+                docRef.updateData(recordData) { error in
+                    if let error = error {
+                        print("데이터 업데이트 실패: \(error.localizedDescription)")
+                        completion(false, error)
+                    } else {
+                        print("데이터 업데이트 성공!")
+                        completion(true, nil)
+                    }
+                }
+            } else {
+                // 새 문서 생성 (createdAt 필드 추가)
+                recordData["createdAt"] = FieldValue.serverTimestamp()
+                
+                docRef.setData(recordData) { error in
+                    if let error = error {
+                        print("새 데이터 저장 실패: \(error.localizedDescription)")
+                        completion(false, error)
+                    } else {
+                        print("새 데이터 저장 성공!")
+                        completion(true, nil)
+                    }
+                }
+            }
+        }
+    }
+    
+    // 특정 날짜의 기록 불러오기
+    func fetchRecord(date: Date, completion: @escaping ([String: Any]?, Error?) -> Void) {
+        // 사용자 ID 가져오기
+        let userId = UserIdManager.shared.getUserId()
+        
+        // 날짜 형식 변환
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let dateString = dateFormatter.string(from: date)
+        
+        // Firestore에서 데이터 조회
+        db.collection(collectionName).document(userId)
+            .collection(subCollectionName).document(dateString)
+            .getDocument { document, error in
+                if let error = error {
+                    print("데이터 불러오기 실패: \(error.localizedDescription)")
+                    completion(nil, error)
+                    return
+                }
+                
+                guard let document = document, document.exists, let data = document.data() else {
+                    print("해당 날짜의 데이터가 존재하지 않습니다.")
+                    completion(nil, nil)
+                    return
+                }
+                
+                completion(data, nil)
+            }
+    }
+    
+    // 특정 사용자의 모든 기록 불러오기
+    func fetchAllRecords(completion: @escaping ([String: [String: Any]]?, Error?) -> Void) {
+        // 사용자 ID 가져오기
+        let userId = UserIdManager.shared.getUserId()
+        
+        // Firestore에서 모든 기록 조회
+        db.collection(collectionName).document(userId)
+            .collection(subCollectionName)
+            .getDocuments { snapshot, error in
+                if let error = error {
+                    print("모든 데이터 불러오기 실패: \(error.localizedDescription)")
+                    completion(nil, error)
+                    return
+                }
+                
+                guard let documents = snapshot?.documents, !documents.isEmpty else {
+                    print("저장된 기록이 없습니다.")
+                    completion([:], nil)
+                    return
+                }
+                
+                var allRecords = [String: [String: Any]]()
+                
+                for document in documents {
+                    let dateString = document.documentID
+                    let data = document.data()
+                    allRecords[dateString] = data
+                }
+                
+                completion(allRecords, nil)
+            }
+    }
+    
+    // 기록 삭제 함수
+    func deleteRecord(date: Date, completion: @escaping (Bool, Error?) -> Void) {
+        // 사용자 ID 가져오기
+        let userId = UserIdManager.shared.getUserId()
+        
+        // 날짜 형식 변환
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let dateString = dateFormatter.string(from: date)
+        
+        // Firestore에서 문서 삭제
+        db.collection(collectionName).document(userId)
+            .collection(subCollectionName).document(dateString)
+            .delete() { error in
+                if let error = error {
+                    print("데이터 삭제 실패: \(error.localizedDescription)")
+                    completion(false, error)
+                } else {
+                    print("데이터 삭제 성공!")
+                    completion(true, nil)
+                }
+            }
+    }
+}

--- a/For Me/For_MeApp.swift
+++ b/For Me/For_MeApp.swift
@@ -1,33 +1,24 @@
 import SwiftUI
 
+import SwiftUI
 import FirebaseCore
 
 
 class AppDelegate: NSObject, UIApplicationDelegate {
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+      
     FirebaseApp.configure()
-    
-    // Firebase 연결 확인을 위한 print 문 추가
-    print("Firebase가 성공적으로 초기화되었습니다.")
-    
-    // Firebase 인스턴스 확인
-    if FirebaseApp.app() != nil {
-      print("Firebase 인스턴스가 존재합니다: \(String(describing: FirebaseApp.app()?.name))")
-    } else {
-      print("Firebase 인스턴스가 존재하지 않습니다.")
-    }
 
     return true
   }
 }
 
-
 @main
 struct ForMeApp: App {
-
-    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/For Me/UserIdClass.swift
+++ b/For Me/UserIdClass.swift
@@ -1,0 +1,44 @@
+import Foundation
+import UIKit
+
+class UserIdManager {
+    // 싱글톤 패턴 구현
+    static let shared = UserIdManager()
+    
+    // UserDefaults 키 상수 정의
+    private let userIdKey = "com.forme.app.userId"
+    
+    private init() {}
+    
+    // 사용자 ID 가져오기 (없으면 생성)
+    func getUserId() -> String {
+        // UserDefaults에서 저장된 ID 확인
+        if let savedUserId = UserDefaults.standard.string(forKey: userIdKey) {
+            return savedUserId
+        }
+        
+        // 저장된 ID가 없으면 새로 생성
+        let newUserId = createNewUserId()
+        UserDefaults.standard.set(newUserId, forKey: userIdKey)
+        
+        return newUserId
+    }
+    
+    // 새 사용자 ID 생성
+    private func createNewUserId() -> String {
+        // UUID 생성 (iOS 디바이스에서 유일한 값)
+        return UUID().uuidString
+    }
+    
+    // 사용자 ID 강제 재설정 (필요 시 사용)
+    func resetUserId() -> String {
+        let newUserId = createNewUserId()
+        UserDefaults.standard.set(newUserId, forKey: userIdKey)
+        return newUserId
+    }
+    
+    // 사용자 ID가 존재하는지 확인
+    func hasUserId() -> Bool {
+        return UserDefaults.standard.string(forKey: userIdKey) != nil
+    }
+}


### PR DESCRIPTION
- FireStoreSave 파일:  DB 구조에 알맞게 데이터 저장하는 기능
- RecordPage 파일: 특정 날짜 클릭 시 Read하여 저장된 정보 불러오기

- 현재 summary는 UserDefaults로 저장하고 있어, Read시 UserDefaults가 우선순위라 해당 정보에서 가져온다.
=> 메모리에 데이터가 쌓이지 않게 하루에 한 번씩 초기화를 하는 방향 혹은 값을 넘겨줄 때 UserDefaults에 저장하지 않고 넘겨주는 방식을 고민

문제점: "AI와 대화하기"는 현재 기능에선 하루에 기준없이 들어가 3번씩 대화 가능하지만, 하루에 한 번만 버튼을 누를 수 있게 바꿀 것(과도한 AI 비용 낭비 방지)