### PR TITLE
요약정보 있을 시 AI 대화 버튼 비활성화

### DIFF
--- a/For Me/RecordPage.swift
+++ b/For Me/RecordPage.swift
@@ -147,7 +147,7 @@ struct RecordPage: View {
                             cancelEditing()
                             showSpeechAIPage = true
                         },
-                        isEnabled: isToday,
+                        isEnabled: isToday && chatSummary == nil,
                         isAdReady: true
                     )
                     .padding(.horizontal)


### PR DESCRIPTION
AI의 무수한 요청을 방지하고자 사용자가 요약 버튼을 눌러 요약 내용이 생성되면 버튼 비활성화 시켰습니다.